### PR TITLE
Add Data Sources subsection and standardisation description

### DIFF
--- a/writing/sections/02_methods.tex
+++ b/writing/sections/02_methods.tex
@@ -7,15 +7,15 @@
 
 \subsection{Data Sources}
 
-We compiled historical time series of respiratory disease burden for respiratory syncytial virus (RSV) and influenza virus (InfV) across eight Chinese cities: Beijing, Lanzhou, Xi'an, Wuhan, Suzhou, Wenzhou, Guangzhou, and Yunfu.
+We compiled historical time series of respiratory disease burden for respiratory syncytial virus (RSV) and influenza virus (influenza) across eight Chinese cities: Beijing, Lanzhou, Xi'an, Wuhan, Suzhou, Wenzhou, Guangzhou, and Yunfu.
 
-These cities were selected because (i) both RSV and InfV surveillance data were available at the city or metropolitan level, (ii) the available data spanned at least five years, and (iii) the data had monthly or weekly temporal resolution.
+These cities were selected because (i) both RSV and influenza surveillance data were available at the city or metropolitan level, (ii) the available data spanned at least five years, and (iii) the data had monthly or weekly temporal resolution.
 
-RSV data were predominantly derived from laboratory-confirmed positivity among acute respiratory infection (ARI) or lower respiratory tract infection (LRTI) inpatients, based on immunofluorescence, antigen testing, PCR, or mixed virological methods depending on the city.
+RSV data were predominantly derived from laboratory-confirmed positivity among acute or lower respiratory tract infection inpatients, using immunofluorescence, antigen testing, PCR, or mixed virological methods depending on the city.
 
-InfV data were obtained from either influenza-like illness (ILI) outpatient positivity surveillance, virological testing data, or clinically reported influenza diagnoses, depending on local surveillance protocols.
+Influenza data were obtained from influenza-like illness (ILI) outpatient positivity surveillance, virological testing data, or clinically reported influenza diagnoses, depending on local surveillance protocols.
 
-Because surveillance system design differs across cities, the raw data represent different but epidemiologically comparable measures of pathogen-specific respiratory disease burden.
+Because surveillance systems differ across cities, the raw data represent different but epidemiologically comparable measures of pathogen-specific respiratory disease burden.
 
 To enable comparison across cities and pathogens, all time series were normalised into dimensionless intensity indices after log-transformation.
 
@@ -23,8 +23,14 @@ A small constant ($\epsilon = 10^{-6}$) was added to zero values prior to log-tr
 
 Cities were classified into northern and southern groups following the conventional Qinling–Huaihe geographical division, which separates regions with distinct climatic and respiratory epidemic profiles.
 
-The resulting normalised time series were used as inputs to derive within-year and between-year cycles described below.
+The selection and compilation of influenza and RSV surveillance data are summarised in Figure~\ref{fig:data_selection}.
 
+\begin{figure}[htbp]
+  \centering
+  \includegraphics[width=0.8\textwidth]{figures/Flu-RSV.png}
+  \caption{Selection and compilation of influenza and RSV data across the eight study cities. (a) Data selection workflow; (b) Geographic coverage and data representation.}
+  \label{fig:data_selection}
+\end{figure}
 
 
 


### PR DESCRIPTION
Added unified description of data sources, north-southThis PR adds the full Data Sources subsection in Methods §1.
The new content:

Describes data sources for RSV and influenza across the selected cities

Clarifies inclusion criteria and time-series resolution requirements

Explains the north–south classification following the Qinling–Huaihe line

Specifies log-transformation and zero-handling (ε = 10^{-6})

States the normalisation procedure used to enable cross-pathogen and cross-city comparability

No other sections were modified.